### PR TITLE
fix: Teleport constructor call in WarpHomeInteraction

### DIFF
--- a/src/main/java/net/darkhax/spellbook/api/interaction/WarpHomeInteraction.java
+++ b/src/main/java/net/darkhax/spellbook/api/interaction/WarpHomeInteraction.java
@@ -33,14 +33,14 @@ public class WarpHomeInteraction extends SimpleInstantInteraction {
         final Ref<EntityStore> ref = context.getEntity();
         final CommandBuffer<EntityStore> commandBuffer = context.getCommandBuffer();
         if (EntityUtils.getEntity(ref, commandBuffer) instanceof Player player) {
-            final Transform transform = getClosestRespawnPoint(player, commandBuffer);
-            if (transform != null) {
-                commandBuffer.addComponent(player.getReference(), Teleport.getComponentType(), new Teleport(null, transform));
+            final Vector3d position = getClosestRespawnPoint(player, commandBuffer);
+            if (position != null) {
+                commandBuffer.addComponent(player.getReference(), Teleport.getComponentType(), new Teleport(position, Vector3f.ZERO));
             }
         }
     }
 
-    private static Transform getClosestRespawnPoint(Player player, ComponentAccessor<EntityStore> componentAccessor) {
+    private static Vector3d getClosestRespawnPoint(Player player, ComponentAccessor<EntityStore> componentAccessor) {
         final World world = player.getWorld();
         final Ref<EntityStore> ref = player.getReference();
         final PlayerConfigData playerData = player.getPlayerConfigData();
@@ -54,11 +54,10 @@ public class WarpHomeInteraction extends SimpleInstantInteraction {
                     final Vector3d posB = b.getRespawnPosition();
                     return Double.compare(playerPos.distanceSquaredTo(posA.x, playerPos.y, posA.z), playerPos.distanceSquaredTo(posB.x, playerPos.y, posB.z));
                 });
-                return new Transform((nearestPos.get()).getRespawnPosition());
+                return nearestPos.get().getRespawnPosition();
             }
         }
         final Transform worldSpawnPoint = world.getWorldConfig().getSpawnProvider().getSpawnPoint(ref, componentAccessor);
-        worldSpawnPoint.setRotation(Vector3f.ZERO);
-        return worldSpawnPoint;
+        return worldSpawnPoint.getPosition();
     }
 }


### PR DESCRIPTION
Description :

 ## Summary
- Fix compilation error in `WarpHomeInteraction` where `Transform` was incorrectly passed to `Teleport` constructor
- Refactor `getClosestRespawnPoint` to return `Vector3d` directly instead of wrapping in `Transform`
- Pass correct parameters to `Teleport(Vector3d position, Vector3f rotation)`

## Changes
- `WarpHomeInteraction.java`:
- Changed `Teleport` instantiation from `new Teleport(null, transform)` to `new Teleport(position, Vector3f.ZERO)`
- Method `getClosestRespawnPoint` now returns `Vector3d` instead of `Transform`